### PR TITLE
Fix mixed content errors for loadDemo

### DIFF
--- a/js/loading.js
+++ b/js/loading.js
@@ -193,7 +193,7 @@ function loadDemo(link, CredsNeeded)
 	if (link == "")
 		return false
 	
-	//Gaurantee that link will use the same protocol as the window
+	//Guarantee that link will use the same protocol as the window
 	var url = new URL(link);
 	url.protocol = window.location.protocol;
 	link = url.href;

--- a/js/loading.js
+++ b/js/loading.js
@@ -193,6 +193,11 @@ function loadDemo(link, CredsNeeded)
 	if (link == "")
 		return false
 	
+	//Gaurantee that link will use the same protocol as the window
+	var url = new URL(link);
+	url.protocol = window.location.protocol;
+	link = url.href;
+	
 	//Manually set query string when loading from a URL
 	if (history.pushState) 
 	{


### PR DESCRIPTION
On some versions and security settings of chrome, the loadDemo function will fail when mixed content is loaded.

As an example, going to _http://br.hogclangaming.com/pr1/_ and then right clicking a link and copy the link address will return something like _http://br.hogclangaming.com/pr1/auto_2019_10_31_23_35_26.bf2demo_. However, because this is using **http** and not the more secure **https**, and thus chrome will automatically block it. My fix solves this by using a URL object to change the protocol to the current window's protocol. This guarantees that they will always match which prevents mixed content issues. We use the current window's protocol because it makes testing locally or in production easier.