### PR TITLE
Add UseFallbackRenderer option

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,9 @@
 						<input type="checkbox" id="options_drawAllOrderIcons" onclick="checkboxClicked(this)">
 						Orders
 						<br>
+						<input type="checkbox" id="options_UseFallbackRenderer" onclick="checkboxClicked(this)">
+						Use Fallback Renderer
+						<br>
 						<input id="options_canvasScale" type="range" min="0.4" max="3.0" value="1.0" step="0.02" oninput="UIScaleChange()">
 						UI Scale
 						<br>

--- a/js/main.js
+++ b/js/main.js
@@ -41,6 +41,7 @@ var options_DrawVehicleHeight = true
 var options_health_players = true
 var options_health_vehicles = true
 var options_drawAllOrderIcons = false
+var options_UseFallbackRenderer = false
 	//}
 
 

--- a/js/maprenderer.js
+++ b/js/maprenderer.js
@@ -76,7 +76,7 @@ class MapRenderer {
 
     // Decide on zoom level and segments
     draw(ctx) {
-        if (this.shouldUseFallback)
+        if (this.shouldUseFallback || options_UseFallbackRenderer)
             return this.drawOld(ctx);
         
 


### PR DESCRIPTION
@AlonTavor's magic voodoo removed map gridlines and DOD overlay because the map segment images used by the new renderer do not have this info. The new renderer seems to always be used ,so shouldUseFallback will always be false. Added an option to force the old renderer in situations where the gridlines/DOD are useful.